### PR TITLE
Añadir paso para agregar IDs a los procesos

### DIFF
--- a/[PRO01]-Proceso-para-definir-un-proceso.md
+++ b/[PRO01]-Proceso-para-definir-un-proceso.md
@@ -31,33 +31,39 @@ las metas de diferentes __áreas del CMMI__ en __menos de un día__.
   </thead>
   <tbody>
     <tr>
-      <td rowspan="4">Análisis</td>
+      <td rowspan="5">Análisis</td>
       <td>1.</td>
+      <td>Definir un identificador para el proceso (véase <a href="https://github.com/novaDepto/Nova/wiki/%5BGUI10%5D-Gu%C3%ADa-de-manejo-de-configuraci%C3%B3n">GUI10</a>)</td>
+      <td>Autor del proceso</td>
+      <td>PPQA, CM</td>
+    </tr>
+    <tr>
+      <td>2.</td>
       <td>Definir un objetivo <a href="#">SMARTish</a> del proceso.</td>
       <td>Autor del proceso</td>
       <td>PPQA, MA</td>
     </tr>
     <tr>
-      <td>2.</td>
+      <td>3.</td>
       <td>Identificar los prerequisitos.</td>
       <td>Autor del proceso</td>
       <td>PPQA</td>
     </tr>
     <tr>
-      <td>3.</td>
+      <td>4.</td>
       <td>Definir las entradas del proceso.</td>
       <td>Autor del proceso</td>
       <td>PPQA</td>
     </tr>
     <tr>
-      <td>4.</td>
+      <td>5.</td>
       <td>Definir las salidas del proceso.</td>
       <td>Autor del proceso</td>
       <td>PPQA</td>
     </tr>
     <tr>
       <td>Definición del proceso</td>
-      <td>5.</td>
+      <td>6.</td>
       <td>Definir los pasos necesarios para generar la salida del proceso,
       identificando las áreas del CMMI a la que pertenecen.</td>
       <td>Autor del proceso</td>
@@ -65,7 +71,7 @@ las metas de diferentes __áreas del CMMI__ en __menos de un día__.
     </tr>
     <tr>
       <td>Calidad</td>
-      <td>6.</td>
+      <td>7.</td>
       <td>Definir las métricas e indicadores necesarios para evaluar la
       calidad de las salidas del proceso</td>
       <td>Autor del proceso</td>
@@ -73,7 +79,7 @@ las metas de diferentes __áreas del CMMI__ en __menos de un día__.
     </tr>
     <tr>
       <td>Verificación</td>
-      <td>7.</td>
+      <td>8.</td>
       <td>
         Corroborar que el proceso tiene mínimo:
         <ul>
@@ -89,7 +95,7 @@ las metas de diferentes __áreas del CMMI__ en __menos de un día__.
     </tr>
     <tr>
       <td>Validación</td>
-      <td>7.</td>
+      <td>9.</td>
       <td>Corroborar con el equipo que las salidas satisfacen la necesidad
       identificada.</td>
       <td>SEPG</td>
@@ -97,13 +103,13 @@ las metas de diferentes __áreas del CMMI__ en __menos de un día__.
     </tr>
     <tr>
       <td rowspan="2">Divulgación</td>
-      <td>8.</td>
+      <td>10.</td>
       <td>Publicar el proceso en la wiki.</td>
       <td>Autor del proceso</td>
       <td>OPF</td>
     </tr>
     <tr>
-      <td>10.</td>
+      <td>11.</td>
       <td>Integrar el proceso en la forma de trabajo del departamento</td>
       <td>Autor del proceso</td>
       <td>OPF</td>

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -4,7 +4,7 @@
 
 * [Proceso para Planificar](https://github.com/novaDepto/Nova/wiki/Proceso-para-Planificar)
 * [Proceso de auditorías](https://github.com/novaDepto/Nova/wiki/Proceso-de-auditor%C3%ADas)
-* [Proceso para definir un proceso](https://github.com/novaDepto/Nova/wiki/Proceso-para-definir-un-proceso)
+* [Proceso para definir un proceso](https://github.com/novaDepto/Nova/wiki/%5BPRO01%5D-Proceso-para-definir-un-proceso)
 * [Proceso para institucionalizar procesos, guías o políticas](https://github.com/novaDepto/Nova/wiki/Proceso-para-institucionalizar-procesos-gu%C3%ADas-y-pol%C3%ADticas)
 * [Proceso para auditorías](https://github.com/novaDepto/Nova/wiki/Proceso-de-auditorías)
 * [Proceso de Daily Meeting](https://github.com/novaDepto/Nova/wiki/Proceso-de-Daily-Meeting)


### PR DESCRIPTION
# Objetivo
Incluir en el proceso de definir procesos un paso para definir el prefijo
identificador del proceso como parte de las necesidades de CM