### PR TITLE
Quitar títulos duplicados, arreglar sidenav

### DIFF
--- a/Guía-para-agendar-eventos.md
+++ b/Guía-para-agendar-eventos.md
@@ -1,6 +1,3 @@
-Guía para crear eventos en el calendario
-=======================================
-
 ## Responsables
 Nombre        | Rol                 |
 --------------|---------------------|

--- a/Proceso-para-Planificar.md
+++ b/Proceso-para-Planificar.md
@@ -1,6 +1,3 @@
-# Proceso para Planificar
-
-
 ## Responsables
 | Nombre    | Rol               | 
 | --------- | ----------------- | 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -2,27 +2,27 @@
 
 ***
 
-* [Proceso para Planificar](https://github.com/novaDepto/Nova/wiki/Proceso-para-Planificar)
-* [Proceso de auditorías](https://github.com/novaDepto/Nova/wiki/Proceso-de-auditor%C3%ADas)
-* [Proceso para definir un proceso](https://github.com/novaDepto/Nova/wiki/%5BPRO01%5D-Proceso-para-definir-un-proceso)
-* [Proceso para institucionalizar procesos, guías o políticas](https://github.com/novaDepto/Nova/wiki/Proceso-para-institucionalizar-procesos-gu%C3%ADas-y-pol%C3%ADticas)
-* [Proceso para auditorías](https://github.com/novaDepto/Nova/wiki/Proceso-de-auditorías)
-* [Proceso de Daily Meeting](https://github.com/novaDepto/Nova/wiki/Proceso-de-Daily-Meeting)
+* [\[PRO01\] Proceso para Planificar](https://github.com/novaDepto/Nova/wiki/Proceso-para-Planificar)
+* [\[PRO02\] Proceso de auditorías](https://github.com/novaDepto/Nova/wiki/Proceso-de-auditor%C3%ADas)
+* [\[PRO03\] Proceso para definir un proceso](https://github.com/novaDepto/Nova/wiki/%5BPRO01%5D-Proceso-para-definir-un-proceso)
+* [\[PRO04\] Proceso para institucionalizar procesos, guías o políticas](https://github.com/novaDepto/Nova/wiki/Proceso-para-institucionalizar-procesos-gu%C3%ADas-y-pol%C3%ADticas)
+* [\[PRO05\] Proceso para auditorías](https://github.com/novaDepto/Nova/wiki/Proceso-de-auditorías)
+* [\[PRO06\] Proceso de Daily Meeting](https://github.com/novaDepto/Nova/wiki/Proceso-de-Daily-Meeting)
 
 ### Guías
 
 ***
-* [Guía del Rol de Program Manager
+* [\[GUI01\] Guía del Rol de Program Manager
 ](https://github.com/novaDepto/Nova/blob/guia/guia-pms/Gu%C3%ADa-del-PM.md)
-* [Guía del Rol de Team Leader
+* [\[GUI02\] Guía del Rol de Team Leader
 ](https://github.com/novaDepto/Nova/blob/master/Gu%C3%ADa-de-Team-Leaders.md)
-* [Guía para crear eventos en el calendario](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-agendar-eventos)
-* [Guía para institucionalizar procesos, guías y políticas](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-institucionalizar-procesos-guías-políticas)
-* [Guía de Nova Flow](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-de-Nova-Flow)
-* [Guía de CMMI](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-de-CMMI)
-* [Guía para las juntas de desempeño](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-las-juntas-de-desempe%C3%B1o)
-* [Guía para las juntas de seguimiento personal ](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-las-juntas-de-seguimiento-personal-(JSP))
-* [Guía para definir un WBS] (https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-definir-un-WBS)
+* [\[GUI03\] Guía para crear eventos en el calendario](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-agendar-eventos)
+* [\[GUI04\] Guía para institucionalizar procesos, guías y políticas](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-institucionalizar-procesos-guías-políticas)
+* [\[GUI05\] Guía de Nova Flow](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-de-Nova-Flow)
+* [\[GUI06\] Guía de CMMI](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-de-CMMI)
+* [\[GUI07\] Guía para las juntas de desempeño](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-las-juntas-de-desempe%C3%B1o)
+* [\[GUI08\] Guía para las juntas de seguimiento personal ](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-las-juntas-de-seguimiento-personal-(JSP))
+* [\[GUI09\] Guía para definir un WBS](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-definir-un-WBS)
 * [\[GUI10\] Guía de manejo de configuración](https://github.com/novaDepto/Nova/wiki/%5BGUI10%5D-Gu%C3%ADa-de-manejo-de-configuraci%C3%B3n)
 * [\[GUI11\] Guía de versionado](https://github.com/novaDepto/Nova/wiki/%5BGUI11%5D-Gu%C3%ADa-de-versionado)
 
@@ -30,9 +30,9 @@
 
 ***
 
-* [Política sobre roles y responsabilidades](https://github.com/novaDepto/Nova/wiki/Pol%C3%ADtica-sobre-roles-y-responsabilidades)
-* [Política de juntas de desempeño](https://github.com/novaDepto/Nova/wiki/Pol%C3%ADtica-de-juntas-de-desempe%C3%B1o)
-* [Política de juntas de seguimiento personal](https://github.com/novaDepto/Nova/wiki/Pol%C3%ADtica-de-juntas-de-seguimiento-personal-(JSP))
+* [\[POL01\] Política sobre roles y responsabilidades](https://github.com/novaDepto/Nova/wiki/Pol%C3%ADtica-sobre-roles-y-responsabilidades)
+* [\[POL02\] Política de juntas de desempeño](https://github.com/novaDepto/Nova/wiki/Pol%C3%ADtica-de-juntas-de-desempe%C3%B1o)
+* [\[POL03\] Política de juntas de seguimiento personal](https://github.com/novaDepto/Nova/wiki/Pol%C3%ADtica-de-juntas-de-seguimiento-personal-(JSP))
 * [\[POL04\] Política-de-Juntas](https://github.com/novaDepto/Nova/wiki/Politica-de-Juntas)
 
 ### Plantillas
@@ -47,5 +47,5 @@
 ***
 
 * [Código de ética](https://github.com/novaDepto/Nova/wiki/C%C3%B3digo-de-%C3%A9tica)
-* [Guía de denuncias](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-de-denuncias)
-* [Proceso de resolución de conflictos](https://github.com/novaDepto/Nova/wiki/Proceso-de-resoluci%C3%B3n-de-conflictos)
+* [\[GUI99\] Guía de denuncias](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-de-denuncias)
+* [\[PRO99\] Proceso de resolución de conflictos](https://github.com/novaDepto/Nova/wiki/Proceso-de-resoluci%C3%B3n-de-conflictos)


### PR DESCRIPTION
Quité títulos repetidos:
* Proceso para planificar
* Guía de eventos

Arreglé también la sidenav:
* Link roto
* Poner ID a cada documento