### PR TITLE
Politica de líneas base

### DIFF
--- a/Politica-de-lineas-base.md
+++ b/Politica-de-lineas-base.md
@@ -22,9 +22,9 @@ Definir las líneas base del departamento con el propósito de:
           <li>  <strong> Controlados:</strong> Para ser modificados deben de pasar por el </li> <a href="https://github.com/novaDepto/Nova/wiki/%5BPRO07%5D-Proceso-de-Modificaci%C3%B3n-de-baseline"> Proceso de modificación de baseline </a>
       </ul>
       <br>
-3. Los elementos de la configuración en línea base corresponden a la última versión que está siendo usada por el departamento o los stakeholders
+2. Los elementos de la configuración en línea base corresponden a la última versión que está siendo usada por el departamento o los stakeholders
 <br>
-5. En el departamento existen 4 líneas base:
+3. En el departamento existen 4 líneas base:
       <ul>
           <li> 
           <a href="https://github.com/novaDepto/Nova/wiki"> Línea base de la Wiki del departamento 

--- a/Politica-de-lineas-base.md
+++ b/Politica-de-lineas-base.md
@@ -24,14 +24,12 @@ Definir las líneas base del departamento con el propósito de:
       <br>
 2. Los elementos de la configuración en línea base corresponden a la última versión que está siendo usada por el departamento o los stakeholders
 <br>
-3. En el departamento existen 4 líneas base:
+3. En el departamento existen 3 líneas base:
       <ul>
           <li> 
           <a href="https://github.com/novaDepto/Nova/wiki"> Línea base de la Wiki del departamento 
           </a> 
           </li>
-          <li> 
-          <a href="https://github.com/novaDepto/Nova/wiki/Directorio-de-archivos-del-departamento"> Línea base del Google Drive del departamento </a> </li>
           <li> <a href="https://github.com/AlonsoOropeza/PugSeal"> Línea base del proyecto Cannis Majoris </a> </li>
           <li> <a href="https://gitlab.com/nova_tec/obcapital">  Línea base del proyecto Andrómeda </a> </li>
       </ul>

--- a/Politica-de-lineas-base.md
+++ b/Politica-de-lineas-base.md
@@ -21,9 +21,7 @@ Definir las líneas base del departamento con el propósito de:
           <li>  <strong> Comunicados:</strong> Sus cambios y existencia son conocidos por los miembros del departamento y han sido publicados en el canal de Slack #nova-foro</li>
           <li>  <strong> Controlados:</strong> Para ser modificados deben de pasar por el </li> <a href="https://github.com/novaDepto/Nova/wiki/%5BPRO07%5D-Proceso-de-Modificaci%C3%B3n-de-baseline"> Proceso de modificación de baseline </a>
       </ul>
-      <br>
 2. Los elementos de la configuración en línea base corresponden a la última versión que está siendo usada por el departamento o los stakeholders
-<br>
 3. En el departamento existen 3 líneas base:
       <ul>
           <li> 

--- a/Politica-de-lineas-base.md
+++ b/Politica-de-lineas-base.md
@@ -19,7 +19,7 @@ Definir las líneas base del departamento con el propósito de:
           <li> <strong>Identificados:</strong> Son productos de trabajo que entran en la categoría de <a href="https://github.com/novaDepto/Nova/wiki/Politica-de-elementos-de-la-configuracion"> elementos de la configuración </a> y siguen la <a href="https://github.com/novaDepto/Nova/wiki/%5BGUI11%5D-Gu%C3%ADa-de-versionado"> guía de versionado </a></li>
           <li> <strong> Auditados:</strong> Han pasado por el <a href="https://github.com/novaDepto/Nova/wiki/%5BPRO07%5D-Proceso-de-Modificaci%C3%B3n-de-baseline"> Proceso de auditoría de CM </a> y por lo tanto revisados por el <a href="https://github.com/novaDepto/Nova/wiki/Politica-de-Configuration-Control-Board"> Configuration Control Board</a> </li>
           <li>  <strong> Comunicados:</strong> Sus cambios y existencia son conocidos por los miembros del departamento y han sido publicados en el canal de Slack #nova-foro</li>
-          <li>  <strong> Controlados:</strong> Para ser modificados deben de pasar por el </li> <a href="https://github.com/novaDepto/Nova/wiki/%5BPRO07%5D-Proceso-de-Modificaci%C3%B3n-de-baseline"> Proceso de modificación de baseline </a>
+          <li>  <strong> Controlados:</strong> Para ser modificados deben de pasar por el <a href="https://github.com/novaDepto/Nova/wiki/%5BPRO07%5D-Proceso-de-Modificaci%C3%B3n-de-baseline"> Proceso de modificación de baseline </a> </li> 
       </ul>
 2. Los elementos de la configuración en línea base corresponden a la última versión que está siendo usada por el departamento o los stakeholders
 3. En el departamento existen 3 líneas base:

--- a/Politica-de-lineas-base.md
+++ b/Politica-de-lineas-base.md
@@ -1,0 +1,37 @@
+## Responsables
+| Nombre    | Rol               | 
+| --------- | ----------------- | 
+|     Daniel Elias      | Autor             | 
+|    Juan Alcántara       | Responsable       |
+|    Carlos Becerra      | Responsable       |
+
+## Objetivos
+Definir las líneas base del departamento con el propósito de: 
+
+* Conocer cuáles son los [elementos de la configuración](https://github.com/novaDepto/Nova/wiki/Politica-de-elementos-de-la-configuracion) que deben de ser consultados por los miembros del departamento y stakeholders. 
+* Evitar confusiones sobre diferentes versiones de documentos o código fuente.
+* Identificar los elementos de la configuración a los que se les puede hacer una petición de cambio.
+
+
+## Reglamento
+1. Una línea base es la especificación de elementos de la configuración que han sido:
+      <ul>
+          <li> <strong>Identificados:</strong> Son productos de trabajo que entran en la categoría de <a href="https://github.com/novaDepto/Nova/wiki/Politica-de-elementos-de-la-configuracion"> elementos de la configuración </a> y siguen la <a href="https://github.com/novaDepto/Nova/wiki/%5BGUI11%5D-Gu%C3%ADa-de-versionado"> guía de versionado </a></li>
+          <li> <strong> Auditados:</strong> Han pasado por el <a href="https://github.com/novaDepto/Nova/wiki/%5BPRO07%5D-Proceso-de-Modificaci%C3%B3n-de-baseline"> Proceso de auditoría de CM </a> y por lo tanto revisados por el <a href="https://github.com/novaDepto/Nova/wiki/Politica-de-Configuration-Control-Board"> Configuration Control Board</a> </li>
+          <li>  <strong> Comunicados:</strong> Sus cambios y existencia son conocidos por los miembros del departamento y han sido publicados en el canal de Slack #nova-foro</li>
+          <li>  <strong> Controlados:</strong> Para ser modificados deben de pasar por el </li> <a href="https://github.com/novaDepto/Nova/wiki/%5BPRO07%5D-Proceso-de-Modificaci%C3%B3n-de-baseline"> Proceso de modificación de baseline </a>
+      </ul>
+      <br>
+3. Los elementos de la configuración en línea base corresponden a la última versión que está siendo usada por el departamento o los stakeholders
+<br>
+5. En el departamento existen 4 líneas base:
+      <ul>
+          <li> 
+          <a href="https://github.com/novaDepto/Nova/wiki"> Línea base de la Wiki del departamento 
+          </a> 
+          </li>
+          <li> 
+          <a href="https://github.com/novaDepto/Nova/wiki/Directorio-de-archivos-del-departamento"> Línea base del Google Drive del departamento </a> </li>
+          <li> <a href="https://github.com/AlonsoOropeza/PugSeal"> Línea base del proyecto Cannis Majoris </a> </li>
+          <li> <a href="https://gitlab.com/nova_tec/obcapital">  Línea base del proyecto Andrómeda </a> </li>
+      </ul>

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -36,6 +36,9 @@
 * [\[POL05\] Política de Nova WoW](https://github.com/novaDepto/Nova/wiki/Politica-de-Nova-WoW)
 
 * [\[POL06\] Política de Comunicación](https://github.com/novaDepto/Nova/wiki/Politica-de-Comunicacion)
+
+* [\[POL10\] Política de líneas base](https://github.com/novaDepto/Nova/wiki/Politica-de-lineas-base)
+
 ### Plantillas
 
 ***


### PR DESCRIPTION
Definir las líneas base del departamento con el propósito de:
- Conocer cuáles son los elementos de la configuración que deben de ser consultados por los miembros del departamento y stakeholders.
- Evitar confusiones sobre diferentes versiones de documentos o código fuente.
- Identificar los elementos de la configuración a los que se les puede hacer una petición de cambio.