### PR TITLE
Cambiar política de CCB

### DIFF
--- a/Politica-de-Configuration-Control-Board.md
+++ b/Politica-de-Configuration-Control-Board.md
@@ -3,8 +3,10 @@
 | --------- | ----------------- | 
 | Daniel Elias    | Autor             | 
 | Juan Alcántara         | Responsable       |
-| Alonso Oropeza         | Responsable       |
 | Pedro González         | Responsable       |
+| Marla Galván        | Responsable       |
+| Raymundo Romero         | Responsable       |
+| Erwin Julian         | Responsable       |
 
 ## Objetivos
 Que el departamento conozca qué es el Configuration Control Board, quiénes lo integran y cuál es el rol de sus miembros
@@ -13,20 +15,23 @@ Que el departamento conozca qué es el Configuration Control Board, quiénes lo 
 1. El __CCB__, por sus siglas en inglés Configuration Control Board, es un grupo de miembros del departamento responsable de __identificar__, __auditar__, __monitorear el status__, __aprobar__ y __rechazar__ [cambios propuestos](https://github.com/novaDepto/Nova/wiki/Proceso-de-Modificaci%C3%B3n-de-baseline) a los [elementos de la configuración](https://github.com/novaDepto/Nova/wiki/Politica-de-elementos-de-la-configuracion) de las [líneas base del departamento](https://github.com/novaDepto/Nova/wiki/Politica-de-lineas-base)
 2. Los miembros del CCB encargados de la [línea base de la wiki del departamento](https://github.com/novaDepto/Nova/wiki) son:
     <ul>
-        <li>Alonso Oropeza</li>
-        <li>Pedro González</li>
-        <li>Juan Alcántara</li>
         <li>PMs actuales</li>
+        <li>Pedro González</li>
+        <li>Marla Galván</li>
+        <li>Juan Alcántara</li>
+        <li>Daniel Elias</li>
+        <li>Raymundo Romero</li>
+        <li>Erwin Julian</li>
     </ul>
 3. Los miembros del CCB encargados de la [línea base del proyecto Cannis Majoris](https://github.com/AlonsoOropeza/PugSeal) son:
     <ul>
+        <li>Arquitecture Owner actual</li>
         <li>Alonso Oropeza</li>
         <li>Daniel Zavalza</li>
-        <li>Arquitecture Owner actual</li>
     </ul>
 4. Los miembros del CCB encargados de la [línea base del proyecto Andrómeda](https://gitlab.com/nova_tec/obcapital) son:
     <ul>
+        <li>Arquitecture Owner actual</li>
         <li>Juan Alcántara</li>
         <li>Pedro González</li>
-        <li>Arquitecture Owner actual</li>
     </ul>


### PR DESCRIPTION
Que el departamento conozca qué es el Configuration Control Board, quiénes lo integran y cuál es el rol de sus miembros