### PR TITLE
Guía de Team Member

### DIFF
--- a/Guía-de-Team-Member.md
+++ b/Guía-de-Team-Member.md
@@ -1,0 +1,76 @@
+## Responsables 
+| Nombre | Rol | 
+| -------- | -------- | 
+| Cristhian    | Responsable     | 
+| Daniel Zavalza    | Autor     | 
+| Marla   | Autor     |
+| Alonso    | Autor     | 
+| Luis    | Autor     |
+| Javier    | Autor     |
+
+
+## Objetivo
+
+Orientar a los integrantes del departamento Nova, a nuevos miembros o a miembros que antes tenían otro rol, sobre las responsabilidades de un Team Member, para así lograr su inclusión rápida al equipo.
+
+## Responsabilidades
+* Produce soluciones que satisfacen las necesidades para los stakeholders
+* Optimiza el uso de recursos
+* Entrenamiento o capacitación de sus compañeros en las actividades que pueda apoyar.
+* Valida y verifica el trabajo del equipo lo antes posible, identificando el medio adecuado para ello.
+* Realiza actividades de:
+    * Pruebas
+    * Análisis
+    * Arquitectura
+    * Diseño
+    * Programación
+    * Planificación
+    * Estimación
+* Cada miembro tiene distinto nivel de habilidades y conocimientos en las distintas actividades, acorde con esto se procura que todos apliquen sus conocimientos en favor de cada área, aportando ideas, estrategias y soluciones que contribuyan al desarrollo del proyecto. Por lo tanto, apoyan a los demás roles de las siguientes maneras:
+    * *Product Owner*:
+        * Darle al PO información de apoyo que favorezca la dirección del proyecto.
+        * Respetar la priorización de tareas que propone el PO.
+    * *Architecture Owner*:
+        * Colaboran de manera directa para desarrollar la estrategia técnica, siempre respetando la autoridad del AO.
+    * *Team Leader*:
+        * Realizan juntas de seguimiento personal y buscan levantar el ánimo, así como la participación activa de los miembros en el departamento. 
+        * Apoyan a garantizar la salud del equipo, mediante un análisis indirecto del ambiente de trabajo para aportar sugerencias y hacer propio dicho ambiente.
+
+## Responsabilidades potenciales
+* Optimizar su forma de trabajo, aprender nuevas habilidades.
+* Mostrarse abierto al trabajo colaborativo en cualquier área.
+* Compartir cualquier información, incluyendo la que está en progreso
+* Ayudar al desarrollo de las habilidades de los miembros del equipo.
+* Expandir sus conocimiento fuera de sus especialidades
+* Trabajar colaborativamente para validar lo trabajado lo antes posible
+* Organizar reuniones reuniones por los medios necesarios
+* Ser proactivo en las actividades de trabajo para mejorar el desempeño del equipo
+* Evitar aceptar trabajo fuera de la iteración sin consultar al equipo.
+
+## Desafíos
+* *Sobre especialización*: 
+    * Las organizaciones de TI tradicionales generalmente propician una sobre especialización en los individuos. Pero los team members deben convertirse en especialistas generalistas, es decir tener más de una especialidad técnica pero a la vez tener conocimiento general sobre otras áreas de desarrollo.
+
+* *Resistencia de la organización al trabajo cruzado-funcional*:
+    *  Lo que quiere decir es que ningún rol es más importante que otro, y una especialización no debe limitar el trabajo a una sola área o persona. Por ejemplo, un PM cree que poner a un tester a hacer el trabajo de un analista de software es inaceptable ya que el analista “gana más y tiene mayor estatus”. Este es un impedimento común en las empresas. DAD sugiere que en vez de que un analista le pase documentos al arquitecto, él al programador, y finalmente él al tester. Todos se involucran en todas las actividades al producir software, desde análisis, modelación, diseño, implementación, pruebas y mantenimiento. 
+
+* *Problemas colaborando efectivamente*: 
+    * Muchos expertos técnicos prefieren trabajar solos más que trabajar colaborativamente en un ambiente de trabajo. Hay varias razones potenciales para esto: Muchas organizaciones adoptan diseños de oficina (como cubículos u oficinas con puertas) estas promueven este tipo de comportamientos, muchas organizaciones promueven la cultura taylorista basada en especialistas que se enfocan en su propio trabajo dejando sus resultados en otros especialistas; y, si, algunas personas técnicas, son introvertidas y no se sienten muy cómodas colaborando y comunicándose proactivamente. Un buen equipo tiene que prestar atención a estos retos y animar a los miembros del equipo a ser más extrovertidos y comunicarse proactivamente en un ambiente sin prejuicios.
+
+* También el team leader y el architecture owner son considerados team members.
+
+## Derechos
+* Ser tratado con respeto
+* Trabajar en un espacio seguro
+* Producir y recibir trabajo de calidad basado en los estándares acordados por el departamento.
+* Apropiarse del proceso de estimación para generar resultados propios de acuerdo a compromisos propios
+* Determinar la forma de trabajo del equipo
+* Ser informado en el tiempo apropiado sobre las decisiones que afectan su trabajo.
+* Escoger y evolucionar su forma de trabajo (WOW)
+
+## Referencias
+* PMI. (n.d.). Rights and Responsibilities – Disciplined Agile (DA). Retrieved September 10, 2020, from https://www.pmi.org/disciplined-agile/people/rights-and-responsibilities.
+* Ambler, S. W., & Lines, M. (2012). Disciplined agile delivery: A practitioner's guide to agile software delivery in the enterprise. Upper Saddle River, NJ: IBM Press.
+
+***
+versión 0.1a

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -50,6 +50,7 @@
 * [\[GUI22\] Guía de Product Owner](https://github.com/novaDepto/Nova/wiki/Guía-del-product-owner)
 * [\[GUI23\] Guía de cuestionario de salud](https://github.com/novaDepto/Nova/wiki/Cuestionario-de-Salud-Discord-Cheatsheet)
 * [\[GUI24\] Guía de identificación de riesgos](https://github.com/novaDepto/Nova/blob/master/Gu%C3%ADa-de-identificaci%C3%B3n-de-riesgos)
+* [\[GUI25\] Guía de Team Member](https://github.com/novaDepto/Nova/blob/master/Guía-de-Team-Member)
 * [\[GUI29\] Guía de denuncias](https://github.com/novaDepto/Nova/wiki/Guía-de-denuncias)
 
 ### Políticas


### PR DESCRIPTION
Orientar a los integrantes del departamento Nova, a nuevos miembros o a miembros que antes tenían otro rol, sobre las responsabilidades de un Team Member, para así lograr su inclusión rápida al equipo.