### PR TITLE
fix: Remover pasos y agregar detalle al proceso

### DIFF
--- a/Proceso-para-generar-un-backlog.md
+++ b/Proceso-para-generar-un-backlog.md
@@ -9,11 +9,10 @@
 ## Objetivo
 Desarrollar un backlog de tareas relacionadas a un plan, para que pueda ser monitoreado y ajustado.
 
-
 ## Entrada 
-1. Lista de las tareas a realizar, ordenadas de mayor a menor riesgo, y por relevancia, de mayor a menor valor.
-3. [Plantilla Plan](https://docs.google.com/spreadsheets/d/1_tEVZlBT36JiXt0Qq1hy3zojkzO2abnw79ju-6LbB4s/edit#gid=976734963) 
-4. Revisar esta [guía para relizar un WBS.](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-definir-un-WBS) 
+1. Lista de necesidades a resolver en un plazo de tiempo definido
+2. [Plantilla Plan](https://docs.google.com/spreadsheets/d/1_tEVZlBT36JiXt0Qq1hy3zojkzO2abnw79ju-6LbB4s/edit#gid=976734963) 
+3. Revisar esta [guía para relizar un WBS.](https://github.com/novaDepto/Nova/wiki/Gu%C3%ADa-para-definir-un-WBS) 
 
 ## Proceso
 <table>
@@ -27,22 +26,25 @@ Desarrollar un backlog de tareas relacionadas a un plan, para que pueda ser moni
   </thead>
   <tbody>
     <tr>
-      <td rowspan="5">Identificación</td>
-      <td>identifica los riesgos relacionados al plan (<strong>Consulta el <a href="https://github.com/novaDepto/Nova/wiki/Proceso-de-gesti%C3%B3n-de-riesgos">Proceso de Gestión de Riesgos</a> para más información).</strong>
-      <td rowspan="5">Autor del plan o integrante</td>
-      <td rowspan="5">PP</td>
+      <td rowspan="6">Identificación</td>
+      <td>Organiza tus necesidades desde más a menos importante</td>
+      <td rowspan="6">Autor del plan o integrante, y <em>Product Owner</em></td>
+      <td rowspan="6">PP</td>
     </tr>
     <tr>
-      <td>Escribe la tarea</td>
+      <td>Empezando por las necesidades más importantes, genera por lo menos una tarea por cada una.</td>
     </tr>
     <tr>
       <td>Establece el área o equipo al que pertenece la tarea.</td>
     </tr>
     <tr>
-      <td>Asigna una prioridad a la tarea.</td>
+      <td>Identifica el valor de la tarea en base al valor que agrega</td>
     </tr>
     <tr>
-      <td>Asigna Agile Points a la tarea (<strong>Consulta la <a href="https://github.com/novaDepto/Nova/wiki/Guía-para-Estimar">Guía para estimar</a> para más información).</strong></td>
+      <td>Determina los <em>Agile Points</em> de la tarea (<strong>Consulta la <a href="https://github.com/novaDepto/Nova/wiki/Guía-para-Estimar">Guía para estimar</a> para más información).</strong></td>
+    </tr>
+    <tr>
+      <td>Identifica los riesgos relacionados al plan (<strong>Consulta el <a href="https://github.com/novaDepto/Nova/wiki/Proceso-de-gesti%C3%B3n-de-riesgos">Proceso de Gestión de Riesgos</a> para más información).</strong>
     </tr>
     <tr>
       <td rowspan="3">Asignación</td>
@@ -58,7 +60,7 @@ Desarrollar un backlog de tareas relacionadas a un plan, para que pueda ser moni
       <td>Establece una fecha estimada de entrega.</td>
       <td>Responsable de la tarea</td>
     </tr>
-    <tr>
+    <!--<tr>
       <td>Medición</td>
       <td>Una vez terminada la tarea, registra las horas que tomó hacerla.</td>
       <td>Participante de la tarea</td>
@@ -81,12 +83,13 @@ Desarrollar un backlog de tareas relacionadas a un plan, para que pueda ser moni
     </tr>
     <tr>
       <td>Actualiza o reformula el plan con base en la desviación.</td>
-    </tr>
+    </tr>-->
   </tbody>
 </table>
 
 ## Salidas
 1. [Plantilla Plan](https://docs.google.com/spreadsheets/d/1_tEVZlBT36JiXt0Qq1hy3zojkzO2abnw79ju-6LbB4s/edit#gid=976734963) 
+2. Fecha estimada del plan
     
 ## Métricas
 1. **SPI** (Schedule Performance Index): ¿Vas adelantado o retrasado conforme a las actividades?
@@ -96,6 +99,6 @@ Desarrollar un backlog de tareas relacionadas a un plan, para que pueda ser moni
 
 ***
 
-Versión 1.1
+Versión 1.2a
 
 


### PR DESCRIPTION
El proceso tenía secciones que pertenecían a los procesos del trabajo
diario, estas fueron removidas. También el proceso pedía como entrada
una lista de tareas organizadas por prioridad, pero esta debería ser
parte de la salida del proceso (esto vaciado en la plantilla del plan).

Faltaba también involucrar al Product Owner para que cuide que los work
items si aportan valor más allá de cualquier otro criterio.

El objetivo es mejorar el flujo de valor incluyendo a roles claves y siendo más específicos.